### PR TITLE
Add December month and rollover tests

### DIFF
--- a/TimeClock.rb
+++ b/TimeClock.rb
@@ -60,7 +60,7 @@ module TimeClock
     #===========================================================================
     # - Month Name def (0 = January)
     #===========================================================================
-    MONTH = ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro"]
+    MONTH = ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"]
     MONTHCOUNT = MONTH.size - 1
     
     #===========================================================================

--- a/spec/time_clock_spec.rb
+++ b/spec/time_clock_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../TimeClock'
+
+RSpec.describe TimeClock do
+  context 'incrementing months' do
+    it 'increments from November to December' do
+      TimeClock.set_day(30)
+      TimeClock.set_week_day(0)
+      TimeClock.set_period(TimeClock::ConfigSetting::PERIODCOUNT)
+      TimeClock.set_month(10) # November
+      TimeClock.set_year(2023)
+
+      TimeClock.clock_tick
+
+      expect(TimeClock.day).to eq(1)
+      expect(TimeClock.month_name).to eq('Dezembro')
+    end
+
+    it 'increments from December to January with year increment' do
+      TimeClock.set_day(31)
+      TimeClock.set_week_day(0)
+      TimeClock.set_period(TimeClock::ConfigSetting::PERIODCOUNT)
+      TimeClock.set_month(11) # December
+      TimeClock.set_year(2023)
+
+      TimeClock.clock_tick
+
+      expect(TimeClock.day).to eq(1)
+      expect(TimeClock.month_name).to eq('Janeiro')
+      expect(TimeClock.year).to eq(2024)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add missing "Dezembro" to TimeClock month names
- add RSpec tests for month rollover from November to December and December to January

## Testing
- `rspec spec/time_clock_spec.rb`


------
https://chatgpt.com/codex/tasks/task_e_688e2ce36d0c8322931401367e39225c